### PR TITLE
rewrite CLI using click & improve/extend filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Luigu/docker workflow to deal with data ingestion.
 
 ## Installation
 
-To install, 
-
 ```
 git clone git@github.com:apsod/trustpipe.git
 cd trustpipe
@@ -177,3 +175,26 @@ luigi --module trustpipe.tasks DockerTask --repo apsod/litbank.git  --branch sma
 ```
 
 This will start a job that downloads some books form litteraturbanken and converts them to plain text using pandoc, putting data in `/data/trustpipe/data/...`
+
+## Command Line Interface (CLI)
+
+The trustpipe CLI is available via the command `trustpipe` and offers various functionalities.
+
+### List Completed Tasks
+A list of completed tasks can be printed with
+`trustpipe list`. The output can be filtered using optional flags. 
+
+```
+$ trustpipe list --help
+
+Usage: trustpipe list [OPTIONS]
+
+  LIST COMPLETED TASKS. USE OPTIONS BELOW TO FILTER JSON FILES.
+
+Options:
+  --jq_filter TEXT  filter json files using jq filter, e.g. '.spec.kind =
+                    "process"'
+  --kind TEXT       filter json files by kind, e.g. process
+  --name TEXT       filter json files by name, e.g. litteraturbanken
+  --help            Show this message and exit.
+```

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='trustpipe',
     version='0.1.0',
-    description='Task orchestratition for data collection and curation',
+    description='Task orchestration for data collection and curation',
     entry_points={
         'console_scripts': [
             'trustpipe = trustpipe.cli:main',
@@ -17,5 +17,7 @@ setup(
         'gitpython==3.1',
         'omegaconf==2.3.0',
         'python-slugify==8.0.1',
+        'jq==1.6.0',
+        'click==8.1.7',
         ]
 )


### PR DESCRIPTION
Changes:
- rewrote `trustpipe` CLI using `click`
- improved filtering for `trustpipe list` using 3 different options: `--jq_filter`, `--kind`, `--name`. Multiple options can be specified and will be applied simultaneously. 

Fixes:
- added `jq` to dependencies